### PR TITLE
Slice and TS-ify yauzl code

### DIFF
--- a/lib/yauzl-ts/Entry.ts
+++ b/lib/yauzl-ts/Entry.ts
@@ -1,0 +1,37 @@
+import {dosDateTimeToDate} from "./internal/utils";
+
+export class Entry {
+    public lastModFileDate: number;
+    public lastModFileTime: number;
+    public generalPurposeBitFlag: number;
+    public compressionMethod: number;
+    public compressedSize: number
+    public uncompressedSize: number
+    public relativeOffsetOfLocalHeader: number
+    public versionMadeBy: number
+    public versionNeededToExtract: number
+    public crc32: number
+    public fileNameLength: number
+    public extraFieldLength: number
+    public fileCommentLength: number
+    public internalFileAttributes: number
+    public externalFileAttributes: number
+    public fileName: string
+    public extraFields: any[]
+    public fileComment: string
+    public comment: string
+
+    constructor() {
+    }
+
+    getLastModDate() {
+        return dosDateTimeToDate(this.lastModFileDate, this.lastModFileTime);
+    };
+    isEncrypted() {
+        return (this.generalPurposeBitFlag & 0x1) !== 0;
+    };
+    isCompressed() {
+        return this.compressionMethod === 8;
+    };
+
+}

--- a/lib/yauzl-ts/RandomAccessReader.ts
+++ b/lib/yauzl-ts/RandomAccessReader.ts
@@ -1,0 +1,96 @@
+import EventEmitter from "node:events";
+import {PassThrough, Readable, Writable} from "stream";
+import {RefUnrefFilter} from "./internal/RefUnrefFilter";
+import {AssertByteCountStream} from "./internal/AssertByteCountStream";
+
+export class RandomAccessReader extends EventEmitter {
+    private refCount: number;
+
+    constructor() {
+        super();
+        this.refCount = 0;
+    }
+
+    ref() {
+        this.refCount += 1;
+    };
+
+    unref() {
+        var self = this;
+        self.refCount -= 1;
+
+        if (self.refCount > 0) return;
+        if (self.refCount < 0) throw new Error("invalid unref");
+
+        self.close(onCloseDone);
+
+        function onCloseDone(err?: Error) {
+            if (err) return self.emit('error', err);
+            self.emit('close');
+        }
+    };
+
+    createReadStream(options: any) {
+        var start = options.start;
+        var end = options.end;
+        if (start === end) {
+            var emptyStream = new PassThrough();
+            setImmediate(function () {
+                emptyStream.end();
+            });
+            return emptyStream;
+        }
+        var stream = this._readStreamForRange(start, end);
+
+        var destroyed = false;
+        var refUnrefFilter = new RefUnrefFilter(this);
+        stream.on("error", function (err) {
+            setImmediate(function () {
+                if (!destroyed) refUnrefFilter.emit("error", err);
+            });
+        });
+        refUnrefFilter.destroy = function () {
+            stream.unpipe(refUnrefFilter);
+            refUnrefFilter.unref();
+            stream.destroy();
+        };
+
+        var byteCounter = new AssertByteCountStream(end - start);
+        refUnrefFilter.on("error", function (err) {
+            setImmediate(function () {
+                if (!destroyed) byteCounter.emit("error", err);
+            });
+        });
+        byteCounter.destroy = function () {
+            destroyed = true;
+            refUnrefFilter.unpipe(byteCounter);
+            refUnrefFilter.destroy();
+        };
+
+        return stream.pipe(refUnrefFilter).pipe(byteCounter);
+    };
+
+    _readStreamForRange(start, end): Readable {
+        throw new Error("not implemented");
+    };
+
+    read(buffer: Buffer, offset: number, length: number, position: number, callback: any) {
+        var readStream = this.createReadStream({start: position, end: position + length});
+        var writeStream = new Writable();
+        var written = 0;
+        writeStream._write = function (chunk, encoding, cb) {
+            chunk.copy(buffer, offset + written, 0, chunk.length);
+            written += chunk.length;
+            cb();
+        };
+        writeStream.on("finish", callback);
+        readStream.on("error", function (error?: Error) {
+            callback(error);
+        });
+        readStream.pipe(writeStream);
+    };
+
+    close(callback: any) {
+        setImmediate(callback);
+    };
+}

--- a/lib/yauzl-ts/ZipFile.ts
+++ b/lib/yauzl-ts/ZipFile.ts
@@ -1,0 +1,405 @@
+import zlib from "node:zlib";
+import {Entry} from "./Entry";
+import {decodeBuffer, emitError, emitErrorAndAutoClose, readAndAssertNoEof, readUInt64LE} from "./internal/utils";
+import {AssertByteCountStream} from "./internal/AssertByteCountStream";
+import EventEmitter from "node:events";
+const crc32 = require("buffer-crc32");
+
+
+export class ZipFile extends EventEmitter{
+    private validateEntrySizes: boolean
+    private reader: any
+    private lazyEntries: boolean
+    private entryCount: number
+    private entriesRead: number
+    private autoClose: boolean
+    private emittedError: boolean
+    private strictFileNames: boolean;
+    private readEntryCursor: any;
+    private fileSize: number;
+    private comment: string;
+    private decodeStrings: boolean;
+    private isOpen: boolean;
+
+
+    constructor(reader: any, centralDirectoryOffset: number, fileSize: number, entryCount: number, comment: string, autoClose: boolean, lazyEntries: boolean, decodeStrings: boolean, validateEntrySizes: boolean, strictFileNames: boolean) {
+        super()
+        this.reader = reader;
+        // forward close events
+        this.reader.on("error", function(err) {
+            // error closing the fd
+            emitError(self, err);
+        });
+        this.reader.once("close", function() {
+            this.emit("close");
+        });
+        this.readEntryCursor = centralDirectoryOffset;
+        this.fileSize = fileSize;
+        this.entryCount = entryCount;
+        this.comment = comment;
+        this.entriesRead = 0;
+        this.autoClose = !!autoClose;
+        this.lazyEntries = !!lazyEntries;
+        this.decodeStrings = !!decodeStrings;
+        this.validateEntrySizes = !!validateEntrySizes;
+        this.strictFileNames = !!strictFileNames;
+        this.isOpen = true;
+        this.emittedError = false;
+
+        if (!this.lazyEntries) this._readEntry();
+    }
+
+    readEntry() {
+        if (!this.lazyEntries) throw new Error("readEntry() called without lazyEntries:true");
+        this._readEntry();
+    };
+    _readEntry() {
+        var self = this;
+        if (self.entryCount === self.entriesRead) {
+            // done with metadata
+            setImmediate(function() {
+                if (self.autoClose) self.close();
+                if (self.emittedError) return;
+                self.emit("end");
+            });
+            return;
+        }
+        if (self.emittedError) return;
+        var buffer = Buffer.allocUnsafe(46);
+        readAndAssertNoEof(self.reader, buffer, 0, buffer.length, self.readEntryCursor, function(err) {
+            if (err) return emitErrorAndAutoClose(self, err);
+            if (self.emittedError) return;
+            var entry = new Entry();
+            // 0 - Central directory file header signature
+            var signature = buffer.readUInt32LE(0);
+            if (signature !== 0x02014b50) return emitErrorAndAutoClose(self, new Error("invalid central directory file header signature: 0x" + signature.toString(16)));
+            // 4 - Version made by
+            entry.versionMadeBy = buffer.readUInt16LE(4);
+            // 6 - Version needed to extract (minimum)
+            entry.versionNeededToExtract = buffer.readUInt16LE(6);
+            // 8 - General purpose bit flag
+            entry.generalPurposeBitFlag = buffer.readUInt16LE(8);
+            // 10 - Compression method
+            entry.compressionMethod = buffer.readUInt16LE(10);
+            // 12 - File last modification time
+            entry.lastModFileTime = buffer.readUInt16LE(12);
+            // 14 - File last modification date
+            entry.lastModFileDate = buffer.readUInt16LE(14);
+            // 16 - CRC-32
+            entry.crc32 = buffer.readUInt32LE(16);
+            // 20 - Compressed size
+            entry.compressedSize = buffer.readUInt32LE(20);
+            // 24 - Uncompressed size
+            entry.uncompressedSize = buffer.readUInt32LE(24);
+            // 28 - File name length (n)
+            entry.fileNameLength = buffer.readUInt16LE(28);
+            // 30 - Extra field length (m)
+            entry.extraFieldLength = buffer.readUInt16LE(30);
+            // 32 - File comment length (k)
+            entry.fileCommentLength = buffer.readUInt16LE(32);
+            // 34 - Disk number where file starts
+            // 36 - Internal file attributes
+            entry.internalFileAttributes = buffer.readUInt16LE(36);
+            // 38 - External file attributes
+            entry.externalFileAttributes = buffer.readUInt32LE(38);
+            // 42 - Relative offset of local file header
+            entry.relativeOffsetOfLocalHeader = buffer.readUInt32LE(42);
+
+            if (entry.generalPurposeBitFlag & 0x40) return emitErrorAndAutoClose(self, new Error("strong encryption is not supported"));
+
+            self.readEntryCursor += 46;
+
+            buffer = Buffer.allocUnsafe(entry.fileNameLength + entry.extraFieldLength + entry.fileCommentLength);
+            readAndAssertNoEof(self.reader, buffer, 0, buffer.length, self.readEntryCursor, function(err) {
+                if (err) return emitErrorAndAutoClose(self, err);
+                if (self.emittedError) return;
+                // 46 - File name
+                var isUtf8 = (entry.generalPurposeBitFlag & 0x800) !== 0;
+                entry.fileName = self.decodeStrings ? decodeBuffer(buffer, 0, entry.fileNameLength, isUtf8)
+                    : buffer.slice(0, entry.fileNameLength);
+
+                // 46+n - Extra field
+                var fileCommentStart = entry.fileNameLength + entry.extraFieldLength;
+                var extraFieldBuffer = buffer.slice(entry.fileNameLength, fileCommentStart);
+                entry.extraFields = [];
+                var i = 0;
+                while (i < extraFieldBuffer.length - 3) {
+                    var headerId = extraFieldBuffer.readUInt16LE(i + 0);
+                    var dataSize = extraFieldBuffer.readUInt16LE(i + 2);
+                    var dataStart = i + 4;
+                    var dataEnd = dataStart + dataSize;
+                    if (dataEnd > extraFieldBuffer.length) return emitErrorAndAutoClose(self, new Error("extra field length exceeds extra field buffer size"));
+                    var dataBuffer = Buffer.allocUnsafe(dataSize);
+                    extraFieldBuffer.copy(dataBuffer, 0, dataStart, dataEnd);
+                    entry.extraFields.push({
+                        id: headerId,
+                        data: dataBuffer,
+                    });
+                    i = dataEnd;
+                }
+
+                // 46+n+m - File comment
+                entry.fileComment = self.decodeStrings ? decodeBuffer(buffer, fileCommentStart, fileCommentStart + entry.fileCommentLength, isUtf8)
+                    : buffer.slice(fileCommentStart, fileCommentStart + entry.fileCommentLength);
+                // compatibility hack for https://github.com/thejoshwolfe/yauzl/issues/47
+                entry.comment = entry.fileComment;
+
+                self.readEntryCursor += buffer.length;
+                self.entriesRead += 1;
+
+                if (entry.uncompressedSize            === 0xffffffff ||
+                    entry.compressedSize              === 0xffffffff ||
+                    entry.relativeOffsetOfLocalHeader === 0xffffffff) {
+                    // ZIP64 format
+                    // find the Zip64 Extended Information Extra Field
+                    var zip64EiefBuffer = null;
+                    for (var i = 0; i < entry.extraFields.length; i++) {
+                        var extraField = entry.extraFields[i];
+                        if (extraField.id === 0x0001) {
+                            zip64EiefBuffer = extraField.data;
+                            break;
+                        }
+                    }
+                    if (zip64EiefBuffer == null) {
+                        return emitErrorAndAutoClose(self, new Error("expected zip64 extended information extra field"));
+                    }
+                    var index = 0;
+                    // 0 - Original Size          8 bytes
+                    if (entry.uncompressedSize === 0xffffffff) {
+                        if (index + 8 > zip64EiefBuffer.length) {
+                            return emitErrorAndAutoClose(self, new Error("zip64 extended information extra field does not include uncompressed size"));
+                        }
+                        entry.uncompressedSize = readUInt64LE(zip64EiefBuffer, index);
+                        index += 8;
+                    }
+                    // 8 - Compressed Size        8 bytes
+                    if (entry.compressedSize === 0xffffffff) {
+                        if (index + 8 > zip64EiefBuffer.length) {
+                            return emitErrorAndAutoClose(self, new Error("zip64 extended information extra field does not include compressed size"));
+                        }
+                        entry.compressedSize = readUInt64LE(zip64EiefBuffer, index);
+                        index += 8;
+                    }
+                    // 16 - Relative Header Offset 8 bytes
+                    if (entry.relativeOffsetOfLocalHeader === 0xffffffff) {
+                        if (index + 8 > zip64EiefBuffer.length) {
+                            return emitErrorAndAutoClose(self, new Error("zip64 extended information extra field does not include relative header offset"));
+                        }
+                        entry.relativeOffsetOfLocalHeader = readUInt64LE(zip64EiefBuffer, index);
+                        index += 8;
+                    }
+                    // 24 - Disk Start Number      4 bytes
+                }
+
+                // check for Info-ZIP Unicode Path Extra Field (0x7075)
+                // see https://github.com/thejoshwolfe/yauzl/issues/33
+                if (self.decodeStrings) {
+                    for (var i = 0; i < entry.extraFields.length; i++) {
+                        var extraField = entry.extraFields[i];
+                        if (extraField.id === 0x7075) {
+                            if (extraField.data.length < 6) {
+                                // too short to be meaningful
+                                continue;
+                            }
+                            // Version       1 byte      version of this extra field, currently 1
+                            if (extraField.data.readUInt8(0) !== 1) {
+                                // > Changes may not be backward compatible so this extra
+                                // > field should not be used if the version is not recognized.
+                                continue;
+                            }
+                            // NameCRC32     4 bytes     File Name Field CRC32 Checksum
+                            var oldNameCrc32 = extraField.data.readUInt32LE(1);
+                            if (crc32.unsigned(buffer.slice(0, entry.fileNameLength)) !== oldNameCrc32) {
+                                // > If the CRC check fails, this UTF-8 Path Extra Field should be
+                                // > ignored and the File Name field in the header should be used instead.
+                                continue;
+                            }
+                            // UnicodeName   Variable    UTF-8 version of the entry File Name
+                            entry.fileName = decodeBuffer(extraField.data, 5, extraField.data.length, true);
+                            break;
+                        }
+                    }
+                }
+
+                // validate file size
+                if (self.validateEntrySizes && entry.compressionMethod === 0) {
+                    var expectedCompressedSize = entry.uncompressedSize;
+                    if (entry.isEncrypted()) {
+                        // traditional encryption prefixes the file data with a header
+                        expectedCompressedSize += 12;
+                    }
+                    if (entry.compressedSize !== expectedCompressedSize) {
+                        var msg = "compressed/uncompressed size mismatch for stored file: " + entry.compressedSize + " != " + entry.uncompressedSize;
+                        return emitErrorAndAutoClose(self, new Error(msg));
+                    }
+                }
+
+                if (self.decodeStrings) {
+                    if (!self.strictFileNames) {
+                        // allow backslash
+                        entry.fileName = entry.fileName.replace(/\\/g, "/");
+                    }
+                    var errorMessage = validateFileName(entry.fileName, self.validateFileNameOptions);
+                    if (errorMessage != null) return emitErrorAndAutoClose(self, new Error(errorMessage));
+                }
+                self.emit("entry", entry);
+
+                if (!self.lazyEntries) self._readEntry();
+            });
+        });
+    };
+
+    openReadStream(entry: Entry, options: any, callback: any) {
+        var self = this;
+        // parameter validation
+        var relativeStart = 0;
+        var relativeEnd = entry.compressedSize;
+        if (callback == null) {
+            callback = options;
+            options = {};
+        } else {
+            // validate options that the caller has no excuse to get wrong
+            if (options.decrypt != null) {
+                if (!entry.isEncrypted()) {
+                    throw new Error("options.decrypt can only be specified for encrypted entries");
+                }
+                if (options.decrypt !== false) throw new Error("invalid options.decrypt value: " + options.decrypt);
+                if (entry.isCompressed()) {
+                    if (options.decompress !== false) throw new Error("entry is encrypted and compressed, and options.decompress !== false");
+                }
+            }
+            if (options.decompress != null) {
+                if (!entry.isCompressed()) {
+                    throw new Error("options.decompress can only be specified for compressed entries");
+                }
+                if (!(options.decompress === false || options.decompress === true)) {
+                    throw new Error("invalid options.decompress value: " + options.decompress);
+                }
+            }
+            if (options.start != null || options.end != null) {
+                if (entry.isCompressed() && options.decompress !== false) {
+                    throw new Error("start/end range not allowed for compressed entry without options.decompress === false");
+                }
+                if (entry.isEncrypted() && options.decrypt !== false) {
+                    throw new Error("start/end range not allowed for encrypted entry without options.decrypt === false");
+                }
+            }
+            if (options.start != null) {
+                relativeStart = options.start;
+                if (relativeStart < 0) throw new Error("options.start < 0");
+                if (relativeStart > entry.compressedSize) throw new Error("options.start > entry.compressedSize");
+            }
+            if (options.end != null) {
+                relativeEnd = options.end;
+                if (relativeEnd < 0) throw new Error("options.end < 0");
+                if (relativeEnd > entry.compressedSize) throw new Error("options.end > entry.compressedSize");
+                if (relativeEnd < relativeStart) throw new Error("options.end < options.start");
+            }
+        }
+        // any further errors can either be caused by the zipfile,
+        // or were introduced in a minor version of yauzl,
+        // so should be passed to the client rather than thrown.
+        if (!self.isOpen) return callback(new Error("closed"));
+        if (entry.isEncrypted()) {
+            if (options.decrypt !== false) return callback(new Error("entry is encrypted, and options.decrypt !== false"));
+        }
+        // make sure we don't lose the fd before we open the actual read stream
+        self.reader.ref();
+        var buffer = Buffer.allocUnsafe(30);
+        readAndAssertNoEof(self.reader, buffer, 0, buffer.length, entry.relativeOffsetOfLocalHeader, function(err?: Error) {
+            try {
+                if (err) return callback(err);
+                // 0 - Local file header signature = 0x04034b50
+                var signature = buffer.readUInt32LE(0);
+                if (signature !== 0x04034b50) {
+                    return callback(new Error("invalid local file header signature: 0x" + signature.toString(16)));
+                }
+                // all this should be redundant
+                // 4 - Version needed to extract (minimum)
+                // 6 - General purpose bit flag
+                // 8 - Compression method
+                // 10 - File last modification time
+                // 12 - File last modification date
+                // 14 - CRC-32
+                // 18 - Compressed size
+                // 22 - Uncompressed size
+                // 26 - File name length (n)
+                var fileNameLength = buffer.readUInt16LE(26);
+                // 28 - Extra field length (m)
+                var extraFieldLength = buffer.readUInt16LE(28);
+                // 30 - File name
+                // 30+n - Extra field
+                var localFileHeaderEnd = entry.relativeOffsetOfLocalHeader + buffer.length + fileNameLength + extraFieldLength;
+                var decompress;
+                if (entry.compressionMethod === 0) {
+                    // 0 - The file is stored (no compression)
+                    decompress = false;
+                } else if (entry.compressionMethod === 8) {
+                    // 8 - The file is Deflated
+                    decompress = options.decompress != null ? options.decompress : true;
+                } else {
+                    return callback(new Error("unsupported compression method: " + entry.compressionMethod));
+                }
+                var fileDataStart = localFileHeaderEnd;
+                var fileDataEnd = fileDataStart + entry.compressedSize;
+                if (entry.compressedSize !== 0) {
+                    // bounds check now, because the read streams will probably not complain loud enough.
+                    // since we're dealing with an unsigned offset plus an unsigned size,
+                    // we only have 1 thing to check for.
+                    if (fileDataEnd > self.fileSize) {
+                        return callback(new Error("file data overflows file bounds: " +
+                            fileDataStart + " + " + entry.compressedSize + " > " + self.fileSize));
+                    }
+                }
+                var readStream = self.reader.createReadStream({
+                    start: fileDataStart + relativeStart,
+                    end: fileDataStart + relativeEnd,
+                });
+                var endpointStream = readStream;
+                if (decompress) {
+                    var destroyed = false;
+                    var inflateFilter = zlib.createInflateRaw();
+                    readStream.on("error", function(err) {
+                        // setImmediate here because errors can be emitted during the first call to pipe()
+                        setImmediate(function() {
+                            if (!destroyed) inflateFilter.emit("error", err);
+                        });
+                    });
+                    readStream.pipe(inflateFilter);
+
+                    if (self.validateEntrySizes) {
+                        endpointStream = new AssertByteCountStream(entry.uncompressedSize);
+                        inflateFilter.on("error", function(err) {
+                            // forward zlib errors to the client-visible stream
+                            setImmediate(function() {
+                                if (!destroyed) endpointStream.emit("error", err);
+                            });
+                        });
+                        inflateFilter.pipe(endpointStream);
+                    } else {
+                        // the zlib filter is the client-visible stream
+                        endpointStream = inflateFilter;
+                    }
+                    // this is part of yauzl's API, so implement this function on the client-visible stream
+                    endpointStream.destroy = function() {
+                        destroyed = true;
+                        if (inflateFilter !== endpointStream) inflateFilter.unpipe(endpointStream);
+                        readStream.unpipe(inflateFilter);
+                        // TODO: the inflateFilter may cause a memory leak. see Issue #27.
+                        readStream.destroy();
+                    };
+                }
+                callback(null, endpointStream);
+            } finally {
+                self.reader.unref();
+            }
+        });
+    };
+
+    close() {
+        if (!this.isOpen) return;
+        this.isOpen = false;
+        this.reader.unref();
+    };
+
+}

--- a/lib/yauzl-ts/inputProcessors.ts
+++ b/lib/yauzl-ts/inputProcessors.ts
@@ -1,0 +1,176 @@
+import fs from "fs";
+import {decodeBuffer, defaultCallback, readAndAssertNoEof, readUInt64LE} from "./internal/utils";
+import {ZipFile} from "./ZipFile";
+
+const fd_slicer = require("fd-slicer");
+
+export function open(path: string, options: any, callback: any) {
+    if (typeof options === "function") {
+        callback = options;
+        options = null;
+    }
+    if (options == null) options = {};
+    if (options.autoClose == null) options.autoClose = true;
+    if (options.lazyEntries == null) options.lazyEntries = false;
+    if (options.decodeStrings == null) options.decodeStrings = true;
+    if (options.validateEntrySizes == null) options.validateEntrySizes = true;
+    if (options.strictFileNames == null) options.strictFileNames = false;
+    if (callback == null) callback = defaultCallback;
+    fs.open(path, "r", function(err, fd) {
+        if (err) return callback(err);
+        fromFd(fd, options, function(err, zipfile) {
+            if (err) fs.close(fd, defaultCallback);
+            callback(err, zipfile);
+        });
+    });
+}
+
+
+export function fromFd(fd: number, options: any, callback: any) {
+    if (typeof options === "function") {
+        callback = options;
+        options = null;
+    }
+    if (options == null) options = {};
+    if (options.autoClose == null) options.autoClose = false;
+    if (options.lazyEntries == null) options.lazyEntries = false;
+    if (options.decodeStrings == null) options.decodeStrings = true;
+    if (options.validateEntrySizes == null) options.validateEntrySizes = true;
+    if (options.strictFileNames == null) options.strictFileNames = false;
+    if (callback == null) callback = defaultCallback;
+    fs.fstat(fd, function(err, stats) {
+        if (err) return callback(err);
+        var reader = fd_slicer.createFromFd(fd, {autoClose: true});
+        fromRandomAccessReader(reader, stats.size, options, callback);
+    });
+}
+
+function fromBuffer(buffer: Buffer, options: any, callback: any) {
+    if (typeof options === "function") {
+        callback = options;
+        options = null;
+    }
+    if (options == null) options = {};
+    options.autoClose = false;
+    if (options.lazyEntries == null) options.lazyEntries = false;
+    if (options.decodeStrings == null) options.decodeStrings = true;
+    if (options.validateEntrySizes == null) options.validateEntrySizes = true;
+    if (options.strictFileNames == null) options.strictFileNames = false;
+    // limit the max chunk size. see https://github.com/thejoshwolfe/yauzl/issues/87
+    var reader = fd_slicer.createFromBuffer(buffer, {maxChunkSize: 0x10000});
+    fromRandomAccessReader(reader, buffer.length, options, callback);
+}
+
+function fromRandomAccessReader(reader: any, totalSize: number, options: any, callback: any) {
+    if (typeof options === "function") {
+        callback = options;
+        options = null;
+    }
+    if (options == null) options = {};
+    if (options.autoClose == null) options.autoClose = true;
+    if (options.lazyEntries == null) options.lazyEntries = false;
+    if (options.decodeStrings == null) options.decodeStrings = true;
+    var decodeStrings = !!options.decodeStrings;
+    if (options.validateEntrySizes == null) options.validateEntrySizes = true;
+    if (options.strictFileNames == null) options.strictFileNames = false;
+    if (callback == null) callback = defaultCallback;
+    if (typeof totalSize !== "number") throw new Error("expected totalSize parameter to be a number");
+    if (totalSize > Number.MAX_SAFE_INTEGER) {
+        throw new Error("zip file too large. only file sizes up to 2^52 are supported due to JavaScript's Number type being an IEEE 754 double.");
+    }
+
+    // the matching unref() call is in zipfile.close()
+    reader.ref();
+
+    // eocdr means End of Central Directory Record.
+    // search backwards for the eocdr signature.
+    // the last field of the eocdr is a variable-length comment.
+    // the comment size is encoded in a 2-byte field in the eocdr, which we can't find without trudging backwards through the comment to find it.
+    // as a consequence of this design decision, it's possible to have ambiguous zip file metadata if a coherent eocdr was in the comment.
+    // we search backwards for a eocdr signature, and hope that whoever made the zip file was smart enough to forbid the eocdr signature in the comment.
+    var eocdrWithoutCommentSize = 22;
+    var maxCommentSize = 0xffff; // 2-byte size
+    var bufferSize = Math.min(eocdrWithoutCommentSize + maxCommentSize, totalSize);
+    var buffer = Buffer.allocUnsafe(bufferSize);
+    var bufferReadStart = totalSize - buffer.length;
+    readAndAssertNoEof(reader, buffer, 0, bufferSize, bufferReadStart, function(err?: Error) {
+        if (err) return callback(err);
+        for (var i = bufferSize - eocdrWithoutCommentSize; i >= 0; i -= 1) {
+            if (buffer.readUInt32LE(i) !== 0x06054b50) continue;
+            // found eocdr
+            var eocdrBuffer = buffer.slice(i);
+
+            // 0 - End of central directory signature = 0x06054b50
+            // 4 - Number of this disk
+            var diskNumber = eocdrBuffer.readUInt16LE(4);
+            if (diskNumber !== 0) {
+                return callback(new Error("multi-disk zip files are not supported: found disk number: " + diskNumber));
+            }
+            // 6 - Disk where central directory starts
+            // 8 - Number of central directory records on this disk
+            // 10 - Total number of central directory records
+            var entryCount = eocdrBuffer.readUInt16LE(10);
+            // 12 - Size of central directory (bytes)
+            // 16 - Offset of start of central directory, relative to start of archive
+            var centralDirectoryOffset = eocdrBuffer.readUInt32LE(16);
+            // 20 - Comment length
+            var commentLength = eocdrBuffer.readUInt16LE(20);
+            var expectedCommentLength = eocdrBuffer.length - eocdrWithoutCommentSize;
+            if (commentLength !== expectedCommentLength) {
+                return callback(new Error("invalid comment length. expected: " + expectedCommentLength + ". found: " + commentLength));
+            }
+            // 22 - Comment
+            // the encoding is always cp437.
+            var comment = decodeStrings ? decodeBuffer(eocdrBuffer, 22, eocdrBuffer.length, false)
+                : eocdrBuffer.slice(22);
+
+            if (!(entryCount === 0xffff || centralDirectoryOffset === 0xffffffff)) {
+                return callback(null, new ZipFile(reader, centralDirectoryOffset, totalSize, entryCount, comment, options.autoClose, options.lazyEntries, decodeStrings, options.validateEntrySizes, options.strictFileNames));
+            }
+
+            // ZIP64 format
+
+            // ZIP64 Zip64 end of central directory locator
+            var zip64EocdlBuffer = Buffer.allocUnsafe(20);
+            var zip64EocdlOffset = bufferReadStart + i - zip64EocdlBuffer.length;
+            readAndAssertNoEof(reader, zip64EocdlBuffer, 0, zip64EocdlBuffer.length, zip64EocdlOffset, function(err) {
+                if (err) return callback(err);
+
+                // 0 - zip64 end of central dir locator signature = 0x07064b50
+                if (zip64EocdlBuffer.readUInt32LE(0) !== 0x07064b50) {
+                    return callback(new Error("invalid zip64 end of central directory locator signature"));
+                }
+                // 4 - number of the disk with the start of the zip64 end of central directory
+                // 8 - relative offset of the zip64 end of central directory record
+                var zip64EocdrOffset = readUInt64LE(zip64EocdlBuffer, 8);
+                // 16 - total number of disks
+
+                // ZIP64 end of central directory record
+                var zip64EocdrBuffer = Buffer.allocUnsafe(56);
+                readAndAssertNoEof(reader, zip64EocdrBuffer, 0, zip64EocdrBuffer.length, zip64EocdrOffset, function(err) {
+                    if (err) return callback(err);
+
+                    // 0 - zip64 end of central dir signature                           4 bytes  (0x06064b50)
+                    if (zip64EocdrBuffer.readUInt32LE(0) !== 0x06064b50) {
+                        return callback(new Error("invalid zip64 end of central directory record signature"));
+                    }
+                    // 4 - size of zip64 end of central directory record                8 bytes
+                    // 12 - version made by                                             2 bytes
+                    // 14 - version needed to extract                                   2 bytes
+                    // 16 - number of this disk                                         4 bytes
+                    // 20 - number of the disk with the start of the central directory  4 bytes
+                    // 24 - total number of entries in the central directory on this disk         8 bytes
+                    // 32 - total number of entries in the central directory            8 bytes
+                    entryCount = readUInt64LE(zip64EocdrBuffer, 32);
+                    // 40 - size of the central directory                               8 bytes
+                    // 48 - offset of start of central directory with respect to the starting disk number     8 bytes
+                    centralDirectoryOffset = readUInt64LE(zip64EocdrBuffer, 48);
+                    // 56 - zip64 extensible data sector                                (variable size)
+                    return callback(null, new ZipFile(reader, centralDirectoryOffset, totalSize, entryCount, comment, options.autoClose, options.lazyEntries, decodeStrings, options.validateEntrySizes, options.strictFileNames));
+                });
+            });
+            return;
+        }
+        callback(new Error("end of central directory record signature not found"));
+    });
+}

--- a/lib/yauzl-ts/internal/AssertByteCountStream.ts
+++ b/lib/yauzl-ts/internal/AssertByteCountStream.ts
@@ -1,0 +1,26 @@
+import {Transform} from "stream";
+
+export class AssertByteCountStream extends Transform{
+    private actualByteCount: number;
+    private expectedByteCount: number;
+    constructor(byteCount: number) {
+        super();
+        this.actualByteCount = 0;
+        this.expectedByteCount = byteCount;
+    }
+    _transform(chunk: any, encoding: any, cb: any) {
+        this.actualByteCount += chunk.length;
+        if (this.actualByteCount > this.expectedByteCount) {
+            var msg = "too many bytes in the stream. expected " + this.expectedByteCount + ". got at least " + this.actualByteCount;
+            return cb(new Error(msg));
+        }
+        cb(null, chunk);
+    };
+    _flush(cb: any) {
+        if (this.actualByteCount < this.expectedByteCount) {
+            var msg = "not enough bytes in the stream. expected " + this.expectedByteCount + ". got only " + this.actualByteCount;
+            return cb(new Error(msg));
+        }
+        cb();
+    };
+}

--- a/lib/yauzl-ts/internal/RefUnrefFilter.ts
+++ b/lib/yauzl-ts/internal/RefUnrefFilter.ts
@@ -1,0 +1,24 @@
+import { PassThrough } from "node:stream";
+
+export class RefUnrefFilter extends PassThrough{
+    private readonly context: any;
+    private unreffedYet: boolean;
+
+    constructor(context: any) {
+        super();
+        this.context = context;
+        this.context.ref();
+        this.unreffedYet = false;
+    }
+
+    _flush(cb: any) {
+        this.unref();
+        cb();
+    }
+
+    unref() {
+        if (this.unreffedYet) return;
+        this.unreffedYet = true;
+        this.context.unref();
+    }
+}

--- a/lib/yauzl-ts/internal/utils.ts
+++ b/lib/yauzl-ts/internal/utils.ts
@@ -1,0 +1,71 @@
+const cp437 = '\u0000☺☻♥♦♣♠•◘○◙♂♀♪♫☼►◄↕‼¶§▬↨↑↓→←∟↔▲▼ !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~⌂ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿⌐¬½¼¡«»░▒▓│┤╡╢╖╕╣║╗╝╜╛┐└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀αßΓπΣσµτΦΘΩδ∞φε∩≡±≥≤⌠⌡÷≈°∙·√ⁿ²■ ';
+
+export function emitErrorAndAutoClose(self: any, err: Error) {
+    if (self.autoClose) self.close();
+    emitError(self, err);
+}
+
+export function emitError(self: any, err: Error) {
+    if (self.emittedError) return;
+    self.emittedError = true;
+    self.emit("error", err);
+}
+
+
+export function dosDateTimeToDate(date: number, time: number) {
+    var day = date & 0x1f; // 1-31
+    var month = (date >> 5 & 0xf) - 1; // 1-12, 0-11
+    var year = (date >> 9 & 0x7f) + 1980; // 0-128, 1980-2108
+
+    var millisecond = 0;
+    var second = (time & 0x1f) * 2; // 0-29, 0-58 (even numbers)
+    var minute = time >> 5 & 0x3f; // 0-59
+    var hour = time >> 11 & 0x1f; // 0-23
+
+    return new Date(year, month, day, hour, minute, second, millisecond);
+}
+
+
+export function readAndAssertNoEof(reader: any, buffer: Buffer, offset: number, length: number, position: number, callback: any) {
+    if (length === 0) {
+        // fs.read will throw an out-of-bounds error if you try to read 0 bytes from a 0 byte file
+        return setImmediate(function() { callback(null, Buffer.allocUnsafe(0)); });
+    }
+    reader.read(buffer, offset, length, position, function(err: Error | undefined, bytesRead: number) {
+        if (err) return callback(err);
+        if (bytesRead < length) {
+            return callback(new Error("unexpected EOF"));
+        }
+        callback();
+    });
+}
+
+
+export function decodeBuffer(buffer: Buffer, start: number, end: number, isUtf8: boolean) {
+    if (isUtf8) {
+        return buffer.toString("utf8", start, end);
+    } else {
+        var result = "";
+        for (var i = start; i < end; i++) {
+            result += cp437[buffer[i]];
+        }
+        return result;
+    }
+}
+
+
+export function readUInt64LE(buffer: Buffer, offset: number) {
+    // there is no native function for this, because we can't actually store 64-bit integers precisely.
+    // after 53 bits, JavaScript's Number type (IEEE 754 double) can't store individual integers anymore.
+    // but since 53 bits is a whole lot more than 32 bits, we do our best anyway.
+    var lower32 = buffer.readUInt32LE(offset);
+    var upper32 = buffer.readUInt32LE(offset + 4);
+    // we can't use bitshifting here, because JavaScript bitshifting only works on 32-bit integers.
+    return upper32 * 0x100000000 + lower32;
+    // as long as we're bounds checking the result of this function against the total file size,
+    // we'll catch any overflow errors, because we already made sure the total file size was within reason.
+}
+
+export function defaultCallback(err?: Error) {
+    if (err) throw err;
+}

--- a/lib/yauzl-ts/validations.ts
+++ b/lib/yauzl-ts/validations.ts
@@ -1,0 +1,13 @@
+export function validateFileName(fileName: string) {
+    if (fileName.indexOf("\\") !== -1) {
+        return "invalid characters in fileName: " + fileName;
+    }
+    if (/^[a-zA-Z]:/.test(fileName) || /^\//.test(fileName)) {
+        return "absolute path: " + fileName;
+    }
+    if (fileName.split("/").indexOf("..") !== -1) {
+        return "invalid relative path: " + fileName;
+    }
+    // all good
+    return null;
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "lint:fix": "eslint . --fix && prettier --write --log-level warn \"**/*.{json,md,ts}\"",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "fd-slicer": "^1.1.0",
+    "buffer-crc32": "~0.2.13"
+  },
   "devDependencies": {
     "@types/node": "^20.11.5",
     "@typescript-eslint/eslint-plugin": "^6.19.0",


### PR DESCRIPTION
fixes #5 

## Changes

This is a first pass of integrating yauzl codebase. It's not going to compile or pass linting yet, but it should represent entire runtime codebase of yauzl, split into separate files and turned into _mostly_ correct TypeScript. I would suggest merging it quickly after quick sanity check and iterating over it in subsequent PRs.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
