### PR TITLE
feat: unzip to generator

### DIFF
--- a/lib/core/unzipomatic.spec.ts
+++ b/lib/core/unzipomatic.spec.ts
@@ -1,14 +1,16 @@
 import { join, resolve } from 'node:path'
 
 import { FileTestHelper } from 'cli-testlab'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest'
 
 import { getTestFileAsBuffer } from '../../test/utils/TestFileSource'
 
 import { readFileSync } from 'fs'
 import { existsSync, statSync } from 'node:fs'
 import { type TestCase, testCases } from '../../test/test-cases'
-import { unzipToFilesystem } from './unzipomatic'
+import type { Entry } from '../yauzl-ts/Entry'
+import { ZipFile } from '../yauzl-ts/ZipFile'
+import { type FileGenerator, unzipToFilesystem, unzipToGenerator } from './unzipomatic'
 
 function ensureExpectedFilesExist(testCase: TestCase, targetDir: string): void {
   if (testCase.expect.success !== true) {
@@ -47,6 +49,57 @@ function ensureExpectedFilesExist(testCase: TestCase, targetDir: string): void {
         ).toBe(true)
       }
     }
+  }
+}
+
+async function ensureExpectedGeneratorExist(
+  testCase: TestCase,
+  generator: FileGenerator,
+): Promise<void> {
+  if (testCase.expect.success !== true) {
+    throw new Error('ensureExpectedFilesExist should only be called for successful test cases')
+  }
+
+  if (testCase.expect.success && testCase.expect.files.length === 0) {
+    const result = await generator.next()
+
+    expect(result.done).toBe(true)
+    expect(result.value).toBeUndefined()
+  }
+
+  const results: Entry[] = []
+
+  for await (const entry of generator) {
+    results.push(entry)
+  }
+
+  expect(results.length).toBe(testCase.expect.files.length)
+
+  expect(
+    results.map((r) => [
+      r.fileName,
+      r.fileName.toString().endsWith('/') ? 'directory' : 'file',
+      r.isEncrypted() ? 0 : r.uncompressedSize,
+    ]),
+  ).to.have.deep.members(
+    testCase.expect.files.map((f) => [
+      f.name,
+      f.type,
+      f.type === 'file' ? (f.encrypted ? 0 : Buffer.byteLength(f.content)) : 0,
+    ]),
+  )
+
+  // TODO: Validate the content of the files
+}
+
+async function readUntilError(generator: FileGenerator): Promise<Error | null> {
+  try {
+    for await (const _entry of generator) {
+    }
+
+    return null
+  } catch (e) {
+    return e as Error
   }
 }
 
@@ -89,5 +142,60 @@ describe('unzipomatic', () => {
         fileHelper.registerForCleanup(targetDir)
       })
     }
+  })
+
+  describe('unzipToReadableGenerator', () => {
+    for (const testCase of testCases) {
+      const skipIfNotUnzip =
+        testCase.expect.success === false && testCase.expect.errorWhile !== 'unzip'
+      const itFn = testCase.expect.success === 'flaky' || skipIfNotUnzip ? it.skip : it
+      const category =
+        testCase.expect.success === true
+          ? 'ok'
+          : testCase.expect.success === 'flaky'
+            ? 'flaky'
+            : 'err'
+
+      itFn(`[${category}] Unzip ${testCase.name}`, async () => {
+        const closeZipFile = vitest.spyOn(ZipFile.prototype, 'close')
+
+        const input = await getTestFileAsBuffer(testCase.path)
+
+        const unzipGenerator = unzipToGenerator(input, testCase.options || {})
+
+        if (testCase.expect.success) {
+          await ensureExpectedGeneratorExist(testCase, unzipGenerator)
+        } else {
+          const result = await readUntilError(unzipGenerator)
+
+          expect(result).toBeInstanceOf(Error)
+          expect(result!.message).toMatchObject(testCase.expect.error!)
+        }
+
+        if (testCase.expect.success || testCase.expect.errorWhile !== 'create')
+          expect(closeZipFile).toHaveBeenCalledOnce()
+      })
+    }
+
+    it('should clean resources if stopped in the middle', async () => {
+      const closeZipFile = vitest.spyOn(ZipFile.prototype, 'close')
+
+      const successTestCase = testCases.find(
+        (t) => t.expect.success === true && t.expect.files.length > 1,
+      )
+
+      expect(successTestCase).not.toBeUndefined()
+
+      const input = await getTestFileAsBuffer(successTestCase!.path)
+      const unzipGenerator = unzipToGenerator(input, successTestCase!.options || {})
+
+      const result = await unzipGenerator.next()
+      expect(result.done).toBe(false)
+
+      const resultDone = await unzipGenerator.return!()
+      expect(resultDone.done).toBe(true)
+
+      expect(closeZipFile).toHaveBeenCalledOnce()
+    })
   })
 })

--- a/lib/yauzl-ts/inputProcessors.ts
+++ b/lib/yauzl-ts/inputProcessors.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 
-import type { IRandomAccessReader, RandomAccessReader } from './RandomAccessReader'
+import type { IRandomAccessReader } from './RandomAccessReader'
 import { ZipFile } from './ZipFile'
 import { decodeBuffer, defaultCallback, readAndAssertNoEof, readUInt64LE } from './internal/utils'
 import { createFromBuffer, createFromFd } from 'better-fd-slicer'
@@ -127,6 +127,15 @@ export function fromBuffer(
   // limit the max chunk size. see https://github.com/thejoshwolfe/yauzl/issues/87
   const reader = createFromBuffer(buffer, { maxChunkSize: 0x10000 })
   fromRandomAccessReader(reader, buffer.length, options, callback)
+}
+
+export function fromBufferAsync(buffer: Buffer, options?: BufferOpenOptions): Promise<ZipFile> {
+  return new Promise((resolve, reject) => {
+    fromBuffer(buffer, options || { }, (err, zipfile) => {
+      if (err) reject(err)
+      else resolve(zipfile!)
+    })
+  })
 }
 
 export function fromRandomAccessReader<TReader extends IRandomAccessReader>(

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "bl": "6.0.11",
     "cli-testlab": "4.0.0",
     "lefthook": "1.6.1",
+    "tslib": "2.6.2",
     "tsup": "8.0.2",
     "typescript": "5.3.3",
     "vitest": "1.3.1"

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -25,6 +25,13 @@ export type SuccessTestCase = {
 
 export type FailureTestCase = {
   success: false;
+  /**
+   * Meanings:
+   * - create: Error during zip file creation
+   * - unzip: Error during zip file extraction
+   * - read: Error during zip fil read content
+   */
+  errorWhile: 'create' | 'unzip' | 'read',
   error: string;
 };
 
@@ -35,6 +42,7 @@ export type FlakyTestCase = {
 export type FileTestCase = {
   type: 'file';
   name: string;
+  encrypted?: boolean;
   content: string;
 } | {
   type: 'directory';
@@ -83,11 +91,11 @@ export const testCases: TestCase[] = [
       files: [
         {
           type: 'directory',
-          name: 'a',
+          name: 'a/',
         },
         {
           type: 'directory',
-          name: 'b',
+          name: 'b/',
         },
         {
           type: 'file',
@@ -152,6 +160,7 @@ export const testCases: TestCase[] = [
         {
           type: 'file',
           name: 'a.txt',
+          encrypted: true,
           content: readTestFileContent('./success/traditional-encryption/a.txt'),
         },
       ]
@@ -167,6 +176,7 @@ export const testCases: TestCase[] = [
         {
           type: 'file',
           name: 'a.bin',
+          encrypted: true,
           content: readTestFileContent('./success/traditional-encryption-and-compression/a.bin'),
         },
       ]
@@ -179,9 +189,21 @@ export const testCases: TestCase[] = [
       success: true,
       files: [
         {
+          type: 'directory',
+          name: 'Turmion Kätilöt/',
+        },
+        {
+          type: 'directory',
+          name: 'Turmion Kätilöt/Hoitovirhe/',
+        },
+        {
           type: 'file',
           name: 'Turmion Kätilöt/Hoitovirhe/Rautaketju.mp3',
           content: readTestFileContent('./success/unicode/Turmion Kätilöt/Hoitovirhe/Rautaketju.mp3'),
+        },
+        {
+          type: 'directory',
+          name: 'Turmion Kätilöt/Pirun nyrkki/',
         },
         {
           type: 'file',
@@ -267,6 +289,7 @@ export const testCases: TestCase[] = [
     name: 'absolute path atxt.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'absolute path: /atxt',
     },
   },
@@ -275,6 +298,7 @@ export const testCases: TestCase[] = [
     name: 'absolute path C xt.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'absolute path: C:/xt',
     },
   },
@@ -283,6 +307,7 @@ export const testCases: TestCase[] = [
     name: 'compressed uncompressed size mismatch for stored file 2147483647 5.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'compressed/uncompressed size mismatch for stored file: 2147483647 != 5',
     },
   },
@@ -291,6 +316,7 @@ export const testCases: TestCase[] = [
     name: 'end of central directory record signature not found.zip',
     expect: {
       success: false,
+      errorWhile: 'create',
       error: 'end of central directory record signature not found',
     },
   },
@@ -299,6 +325,7 @@ export const testCases: TestCase[] = [
     name: 'end of central directory record signature not found_1.zip',
     expect: {
       success: false,
+      errorWhile: 'create',
       error: 'end of central directory record signature not found',
     },
   },
@@ -307,6 +334,7 @@ export const testCases: TestCase[] = [
     name: 'expected zip64 extended information extra field.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'expected zip64 extended information extra field',
     },
   },
@@ -315,6 +343,7 @@ export const testCases: TestCase[] = [
     name: 'extra field length exceeds extra field buffer size.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'extra field length exceeds extra field buffer size',
     },
   },
@@ -323,6 +352,7 @@ export const testCases: TestCase[] = [
     name: 'file data overflows file bounds 63 2147483647 308.zip',
     expect: {
       success: false,
+      errorWhile: 'read',
       error: 'file data overflows file bounds: 63 + 2147483647 > 308',
     },
   },
@@ -331,6 +361,7 @@ export const testCases: TestCase[] = [
     name: 'invalid central directory file header signature 0x1014b50.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'invalid central directory file header signature: 0x1014b50',
     },
   },
@@ -346,6 +377,7 @@ export const testCases: TestCase[] = [
     name: 'invalid comment length expected 1 found 0.zip',
     expect: {
       success: false,
+      errorWhile: 'create',
       error: 'invalid comment length. expected: 1. found: 0',
     },
   },
@@ -354,6 +386,7 @@ export const testCases: TestCase[] = [
     name: 'invalid local file header signature 0x3034b50.zip',
     expect: {
       success: false,
+      errorWhile: 'read',
       error: 'invalid local file header signature: 0x3034b50',
     },
   },
@@ -362,6 +395,7 @@ export const testCases: TestCase[] = [
     name: 'invalid relative path xt.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'invalid relative path: ../xt',
     },
   },
@@ -370,6 +404,7 @@ export const testCases: TestCase[] = [
     name: 'invalid zip64 end of central directory locator signature.zip',
     expect: {
       success: false,
+      errorWhile: 'create',
       error: 'invalid zip64 end of central directory locator signature',
     },
   },
@@ -378,6 +413,7 @@ export const testCases: TestCase[] = [
     name: 'invalid zip64 end of central directory record signature.zip',
     expect: {
       success: false,
+      errorWhile: 'create',
       error: 'invalid zip64 end of central directory record signature',
     },
   },
@@ -386,6 +422,7 @@ export const testCases: TestCase[] = [
     name: 'multi-disk zip files are not supported found disk number 1.zip',
     expect: {
       success: false,
+      errorWhile: 'create',
       error: 'multi-disk zip files are not supported: found disk number: 1',
     },
   },
@@ -401,6 +438,7 @@ export const testCases: TestCase[] = [
     name: 'strong encryption is not supported.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'strong encryption is not supported',
     },
   },
@@ -423,6 +461,7 @@ export const testCases: TestCase[] = [
     name: 'unsupported compression method 1.zip',
     expect: {
       success: false,
+      errorWhile: 'read',
       error: 'unsupported compression method: 1',
     },
   },
@@ -431,6 +470,7 @@ export const testCases: TestCase[] = [
     name: 'zip64 extended information extra field does not include compressed size.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'zip64 extended information extra field does not include compressed size',
     },
   },
@@ -439,6 +479,7 @@ export const testCases: TestCase[] = [
     name: 'zip64 extended information extra field does not include relative header offset.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'zip64 extended information extra field does not include relative header offset',
     },
   },
@@ -447,6 +488,7 @@ export const testCases: TestCase[] = [
     name: 'zip64 extended information extra field does not include uncompressed size.zip',
     expect: {
       success: false,
+      errorWhile: 'unzip',
       error: 'zip64 extended information extra field does not include uncompressed size',
     },
   },


### PR DESCRIPTION
## Changes

Adds support to unzip via generators.

## Checklist

- [x] Waiting for #23 to be merged.
- [x] Add tests.
- [x] ~Make tests validate the name/size/content/type of the files.~ Only missing content.
- [x] ~Add correct types for `Entry`.~ This type already had the correct fields.
