### PR TITLE
feat(entry): move openReadStream to Entry & add getBuffer to Entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,6 @@ jobs:
         run: |
           npm run build
 
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          version: latest
-
-      - name: Run Biome
-        run: biome ci .
-
       - name: Run Linting & Tests
         run: |
           npm run test:ci

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export {}
+export type {}

--- a/lib/core/unzipomatic.spec.ts
+++ b/lib/core/unzipomatic.spec.ts
@@ -5,8 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest'
 
 import { getTestFileAsBuffer } from '../../test/utils/TestFileSource'
 
-import { readFileSync } from 'fs'
-import { existsSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { type TestCase, testCases } from '../../test/test-cases'
 import type { Entry } from '../yauzl-ts/Entry'
 import { ZipFile } from '../yauzl-ts/ZipFile'

--- a/lib/yauzl-ts/Entry.ts
+++ b/lib/yauzl-ts/Entry.ts
@@ -1,4 +1,8 @@
-import { dosDateTimeToDate } from './internal/utils'
+import { dosDateTimeToDate, readAndAssertNoEofAsync } from './internal/utils'
+import type { Transform } from 'stream'
+import zlib from 'node:zlib'
+import { AssertByteCountStream } from './internal/AssertByteCountStream'
+import { ZipFile } from './ZipFile'
 
 export type EntryExtraField = { id: number; data: Buffer }
 
@@ -23,6 +27,10 @@ export class Entry {
   public fileComment!: string | Buffer
   public comment!: string | Buffer
 
+  constructor(
+    protected readonly zipFile: ZipFile,
+  ) { }
+
   getLastModDate() {
     return dosDateTimeToDate(this.lastModFileDate, this.lastModFileTime)
   }
@@ -33,5 +41,150 @@ export class Entry {
 
   isCompressed() {
     return this.compressionMethod === 8
+  }
+
+  isDirectory(): any {
+    if (typeof this.fileName === 'string') {
+      return this.fileName.endsWith('/')
+    }
+
+    return this.fileName[this.fileName.length - 1] === '/'.charCodeAt(0)
+  }
+
+  async getStream(): Promise<Transform> {
+    const relativeStart = 0
+    const relativeEnd = this.compressedSize
+
+    // any further errors can either be caused by the zipfile,
+    // or were introduced in a minor version of yauzl,
+    // so should be passed to the client rather than thrown.
+    if (!this.zipFile.isOpen)
+      throw new Error('The content of the file can only be read while the zip file is open.')
+
+    // make sure we don't lose the fd before we open the actual read stream
+    this.zipFile.reader.ref()
+    const buffer = Buffer.allocUnsafe(30)
+
+    await readAndAssertNoEofAsync(
+      this.zipFile.reader,
+      buffer,
+      0,
+      buffer.length,
+      this.relativeOffsetOfLocalHeader,
+    );
+
+    try {
+      // 0 - Local file header signature = 0x04034b50
+      const signature = buffer.readUInt32LE(0)
+
+      if (signature !== 0x04034b50) {
+        throw new Error(`invalid local file header signature: 0x${signature.toString(16)}`)
+      }
+
+      // all this should be redundant
+      // 4 - Version needed to extract (minimum)
+      // 6 - General purpose bit flag
+      // 8 - Compression method
+      // 10 - File last modification time
+      // 12 - File last modification date
+      // 14 - CRC-32
+      // 18 - Compressed size
+      // 22 - Uncompressed size
+      // 26 - File name length (n)
+      const fileNameLength = buffer.readUInt16LE(26)
+      // 28 - Extra field length (m)
+      const extraFieldLength = buffer.readUInt16LE(28)
+      // 30 - File name
+      // 30+n - Extra field
+      const localFileHeaderEnd =
+        this.relativeOffsetOfLocalHeader + buffer.length + fileNameLength + extraFieldLength
+
+      let decompress: boolean
+      if (this.compressionMethod === 0) {
+        // 0 - The file is stored (no compression)
+        decompress = false
+      } else if (this.compressionMethod === 8) {
+        // 8 - The file is Deflated
+        decompress = !this.isEncrypted()
+      } else {
+        throw new Error(`unsupported compression method: ${this.compressionMethod}`)
+      }
+
+      const fileDataStart = localFileHeaderEnd
+      const fileDataEnd = fileDataStart + this.compressedSize
+      if (this.compressedSize !== 0) {
+        // bounds check now, because the read streams will probably not complain loud enough.
+        // since we're dealing with an unsigned offset plus an unsigned size,
+        // we only have 1 thing to check for.
+        if (fileDataEnd > this.zipFile.fileSize) {
+          throw new Error(
+            `file data overflows file bounds: ${fileDataStart} + ${this.compressedSize} > ${this.zipFile.fileSize}`,
+          )
+        }
+      }
+
+      const readStream = this.zipFile.reader.createReadStream({
+        start: fileDataStart + relativeStart,
+        end: fileDataStart + relativeEnd,
+      })
+
+      let endpointStream = readStream as Transform
+      if (decompress) {
+        let destroyed = false
+        const inflateFilter = zlib.createInflateRaw()
+        readStream.on('error', (err: Error) => {
+          // setImmediate here because errors can be emitted during the first call to pipe()
+          setImmediate(() => {
+            if (!destroyed) inflateFilter.emit('error', err)
+          })
+        })
+        readStream.pipe(inflateFilter)
+
+        if (this.zipFile.validateEntrySizes) {
+          endpointStream = new AssertByteCountStream(this.uncompressedSize)
+          inflateFilter.on('error', (err) => {
+            // forward zlib errors to the client-visible stream
+            setImmediate(() => {
+              if (!destroyed) endpointStream.emit('error', err)
+            })
+          })
+          inflateFilter.pipe(endpointStream)
+        } else {
+          // the zlib filter is the client-visible stream
+          endpointStream = inflateFilter
+        }
+
+        // this is part of yauzl's API, so implement this function on the client-visible stream
+        endpointStream.destroy = function () {
+          destroyed = true
+          if (inflateFilter !== endpointStream) inflateFilter.unpipe(endpointStream)
+          readStream.unpipe(inflateFilter)
+          // TODO: the inflateFilter may cause a memory leak. see Issue #27.
+          readStream.destroy()
+
+          return this
+        }
+      }
+
+      return endpointStream
+    } finally {
+      this.zipFile.reader.unref()
+    }
+  }
+
+  /**
+   * Get the file content as a Buffer.
+   *
+   * @throws {Error} If the zip file was closed.
+   */
+  public async getBuffer(): Promise<Buffer> {
+    const stream = await this.getStream()
+    const buffers: Buffer[] = []
+
+    for await (const chunk of stream) {
+      buffers.push(chunk)
+    }
+
+    return Buffer.concat(buffers)
   }
 }

--- a/lib/yauzl-ts/Entry.ts
+++ b/lib/yauzl-ts/Entry.ts
@@ -1,5 +1,5 @@
 import { dosDateTimeToDate, readAndAssertNoEofAsync } from './internal/utils'
-import type { Transform } from 'stream'
+import type { Transform } from 'node:stream'
 import zlib from 'node:zlib'
 import { AssertByteCountStream } from './internal/AssertByteCountStream'
 import { ZipFile } from './ZipFile'

--- a/lib/yauzl-ts/RandomAccessReader.ts
+++ b/lib/yauzl-ts/RandomAccessReader.ts
@@ -4,7 +4,7 @@ import { PassThrough, Writable } from 'stream'
 import { AssertByteCountStream } from './internal/AssertByteCountStream'
 import { RefUnrefFilter } from './internal/RefUnrefFilter'
 import EventEmitter from 'node:events'
-import { FdSlicer, ReadStream } from 'better-fd-slicer'
+import { ReadStream } from 'better-fd-slicer'
 
 export interface RandomAccessReaderCreateReadStream {
   start: number
@@ -12,6 +12,8 @@ export interface RandomAccessReaderCreateReadStream {
 }
 
 export interface IRandomAccessReader extends EventEmitter {
+  refCount: number;
+
   createReadStream(options: { start?: number, end?: number }): Transform | ReadStream
 
   read(
@@ -28,7 +30,7 @@ export interface IRandomAccessReader extends EventEmitter {
 }
 
 export class RandomAccessReader extends EventEmitter implements IRandomAccessReader {
-  private refCount: number
+  public refCount: number
 
   constructor() {
     super()

--- a/lib/yauzl-ts/inputProcessors.ts
+++ b/lib/yauzl-ts/inputProcessors.ts
@@ -1,9 +1,9 @@
-import fs from 'fs'
+import fs from 'node:fs'
 
+import { createFromBuffer, createFromFd } from 'better-fd-slicer'
 import type { IRandomAccessReader } from './RandomAccessReader'
 import { ZipFile } from './ZipFile'
 import { decodeBuffer, defaultCallback, readAndAssertNoEof, readUInt64LE } from './internal/utils'
-import { createFromBuffer, createFromFd } from 'better-fd-slicer'
 
 export interface OpenOptions {
   autoClose?: boolean

--- a/lib/yauzl-ts/internal/RefUnrefFilter.ts
+++ b/lib/yauzl-ts/internal/RefUnrefFilter.ts
@@ -14,6 +14,10 @@ export class RefUnrefFilter<TReader extends IRandomAccessReader> extends PassThr
     this.unreffedYet = false
   }
 
+  get refCount(): number {
+    return this.context.refCount;
+  }
+
   _flush(cb: () => void) {
     this.unref()
     cb()

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json --noEmit && tsup",
     "test": "vitest --coverage",
-    "test:ci": "npm run lint && npm run test",
+    "test:ci": "npm run lint:ci && npm run test",
     "lint": "biome lint .",
+    "lint:ci": "biome ci .",
     "lint:fix": "biome check --apply .",
     "prepublishOnly": "npm run build"
   },
@@ -56,7 +57,7 @@
     "buffer-crc32": "1.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.5.3",
+    "@biomejs/biome": "1.7.3",
     "@types/buffer-crc32": "0.2.4",
     "@types/node": "20.11.19",
     "@vitest/coverage-v8": "1.3.1",

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -1,6 +1,5 @@
 import { join } from 'node:path'
 import { readFileSync } from 'fs'
-import type { UnzipOptions } from '../lib/core/unzipomatic'
 
 const readTestFileContent = (filename: string) => {
   try {
@@ -14,7 +13,6 @@ const readTestFileContent = (filename: string) => {
 export type TestCase = {
   path: string;
   name: string;
-  options?: UnzipOptions;
   expect: SuccessTestCase | FailureTestCase | FlakyTestCase
 }
 
@@ -169,7 +167,6 @@ export const testCases: TestCase[] = [
   {
     path: join('./success/traditional-encryption-and-compression.zip'),
     name: 'traditional-encryption-and-compression.zip',
-    options: { decompress: false },
     expect: {
       success: true,
       files: [

--- a/test/test-cases.ts
+++ b/test/test-cases.ts
@@ -1,5 +1,5 @@
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { readFileSync } from 'fs'
 
 const readTestFileContent = (filename: string) => {
   try {


### PR DESCRIPTION
## Changes

Moved `openReadStream` to `Entry`, I also renamed that method to `getStream` and also added `getBuffer`.

I added content test to `unzipToGenerator` and added more errors in different cases.

I also removed the `options` to get the content of the file, being honest, we had too many options that I think was not useful.

If the user wants to get the content of the buffer, of course, they want the content to be `uncompressed` and also `decrypted` if possible, at least for me, it didn't make sense to throw an error during those cases. But one thing we should do in the future is add docs about how to decrypt the content of the zip file (and also decompress if is also compressed).

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
