### PR TITLE
feat(readable): add support to readable

### DIFF
--- a/lib/yauzl-ts/Entry.ts
+++ b/lib/yauzl-ts/Entry.ts
@@ -6,7 +6,7 @@ import { ZipFile } from './ZipFile'
 
 export type EntryExtraField = { id: number; data: Buffer }
 
-export class Entry {
+export abstract class BaseEntry {
   public lastModFileDate!: number
   public lastModFileTime!: number
   public generalPurposeBitFlag!: number
@@ -27,10 +27,6 @@ export class Entry {
   public fileComment!: string | Buffer
   public comment!: string | Buffer
 
-  constructor(
-    protected readonly zipFile: ZipFile,
-  ) { }
-
   getLastModDate() {
     return dosDateTimeToDate(this.lastModFileDate, this.lastModFileTime)
   }
@@ -50,126 +46,154 @@ export class Entry {
 
     return this.fileName[this.fileName.length - 1] === '/'.charCodeAt(0)
   }
+}
 
-  async getStream(): Promise<Transform> {
-    const relativeStart = 0
-    const relativeEnd = this.compressedSize
+export async function getStreamFromEntry(zipFile: ZipFile, entry: BaseEntry): Promise<Transform> {
+  const relativeStart = 0
+  const relativeEnd = entry.compressedSize
 
-    // any further errors can either be caused by the zipfile,
-    // or were introduced in a minor version of yauzl,
-    // so should be passed to the client rather than thrown.
-    if (!this.zipFile.isOpen)
-      throw new Error('The content of the file can only be read while the zip file is open.')
+  // any further errors can either be caused by the zipfile,
+  // or were introduced in a minor version of yauzl,
+  // so should be passed to the client rather than thrown.
+  if (!zipFile.isOpen)
+    throw new Error('The content of the file can only be read while the zip file is open.')
 
-    // make sure we don't lose the fd before we open the actual read stream
-    this.zipFile.reader.ref()
-    const buffer = Buffer.allocUnsafe(30)
+  // make sure we don't lose the fd before we open the actual read stream
+  zipFile.reader.ref()
+  const buffer = Buffer.allocUnsafe(30)
 
-    await readAndAssertNoEofAsync(
-      this.zipFile.reader,
-      buffer,
-      0,
-      buffer.length,
-      this.relativeOffsetOfLocalHeader,
-    );
+  await readAndAssertNoEofAsync(
+    zipFile.reader,
+    buffer,
+    0,
+    buffer.length,
+    entry.relativeOffsetOfLocalHeader,
+  );
 
-    try {
-      // 0 - Local file header signature = 0x04034b50
-      const signature = buffer.readUInt32LE(0)
+  try {
+    // 0 - Local file header signature = 0x04034b50
+    const signature = buffer.readUInt32LE(0)
 
-      if (signature !== 0x04034b50) {
-        throw new Error(`invalid local file header signature: 0x${signature.toString(16)}`)
+    if (signature !== 0x04034b50) {
+      throw new Error(`invalid local file header signature: 0x${signature.toString(16)}`)
+    }
+
+    // all this should be redundant
+    // 4 - Version needed to extract (minimum)
+    // 6 - General purpose bit flag
+    // 8 - Compression method
+    // 10 - File last modification time
+    // 12 - File last modification date
+    // 14 - CRC-32
+    // 18 - Compressed size
+    // 22 - Uncompressed size
+    // 26 - File name length (n)
+    const fileNameLength = buffer.readUInt16LE(26)
+    // 28 - Extra field length (m)
+    const extraFieldLength = buffer.readUInt16LE(28)
+    // 30 - File name
+    // 30+n - Extra field
+    const localFileHeaderEnd =
+      entry.relativeOffsetOfLocalHeader + buffer.length + fileNameLength + extraFieldLength
+
+    let decompress: boolean
+    if (entry.compressionMethod === 0) {
+      // 0 - The file is stored (no compression)
+      decompress = false
+    } else if (entry.compressionMethod === 8) {
+      // 8 - The file is Deflated
+      decompress = !entry.isEncrypted()
+    } else {
+      throw new Error(`unsupported compression method: ${entry.compressionMethod}`)
+    }
+
+    const fileDataStart = localFileHeaderEnd
+    const fileDataEnd = fileDataStart + entry.compressedSize
+    if (entry.compressedSize !== 0) {
+      // bounds check now, because the read streams will probably not complain loud enough.
+      // since we're dealing with an unsigned offset plus an unsigned size,
+      // we only have 1 thing to check for.
+      if (fileDataEnd > zipFile.fileSize) {
+        throw new Error(
+          `file data overflows file bounds: ${fileDataStart} + ${entry.compressedSize} > ${zipFile.fileSize}`,
+        )
       }
+    }
 
-      // all this should be redundant
-      // 4 - Version needed to extract (minimum)
-      // 6 - General purpose bit flag
-      // 8 - Compression method
-      // 10 - File last modification time
-      // 12 - File last modification date
-      // 14 - CRC-32
-      // 18 - Compressed size
-      // 22 - Uncompressed size
-      // 26 - File name length (n)
-      const fileNameLength = buffer.readUInt16LE(26)
-      // 28 - Extra field length (m)
-      const extraFieldLength = buffer.readUInt16LE(28)
-      // 30 - File name
-      // 30+n - Extra field
-      const localFileHeaderEnd =
-        this.relativeOffsetOfLocalHeader + buffer.length + fileNameLength + extraFieldLength
+    const readStream = zipFile.reader.createReadStream({
+      start: fileDataStart + relativeStart,
+      end: fileDataStart + relativeEnd,
+    })
 
-      let decompress: boolean
-      if (this.compressionMethod === 0) {
-        // 0 - The file is stored (no compression)
-        decompress = false
-      } else if (this.compressionMethod === 8) {
-        // 8 - The file is Deflated
-        decompress = !this.isEncrypted()
-      } else {
-        throw new Error(`unsupported compression method: ${this.compressionMethod}`)
-      }
-
-      const fileDataStart = localFileHeaderEnd
-      const fileDataEnd = fileDataStart + this.compressedSize
-      if (this.compressedSize !== 0) {
-        // bounds check now, because the read streams will probably not complain loud enough.
-        // since we're dealing with an unsigned offset plus an unsigned size,
-        // we only have 1 thing to check for.
-        if (fileDataEnd > this.zipFile.fileSize) {
-          throw new Error(
-            `file data overflows file bounds: ${fileDataStart} + ${this.compressedSize} > ${this.zipFile.fileSize}`,
-          )
-        }
-      }
-
-      const readStream = this.zipFile.reader.createReadStream({
-        start: fileDataStart + relativeStart,
-        end: fileDataStart + relativeEnd,
+    let endpointStream = readStream as Transform
+    if (decompress) {
+      let destroyed = false
+      const inflateFilter = zlib.createInflateRaw()
+      readStream.on('error', (err: Error) => {
+        // setImmediate here because errors can be emitted during the first call to pipe()
+        setImmediate(() => {
+          if (!destroyed) inflateFilter.emit('error', err)
+        })
       })
+      readStream.pipe(inflateFilter)
 
-      let endpointStream = readStream as Transform
-      if (decompress) {
-        let destroyed = false
-        const inflateFilter = zlib.createInflateRaw()
-        readStream.on('error', (err: Error) => {
-          // setImmediate here because errors can be emitted during the first call to pipe()
+      if (zipFile.validateEntrySizes) {
+        endpointStream = new AssertByteCountStream(entry.uncompressedSize)
+        inflateFilter.on('error', (err) => {
+          // forward zlib errors to the client-visible stream
           setImmediate(() => {
-            if (!destroyed) inflateFilter.emit('error', err)
+            if (!destroyed) endpointStream.emit('error', err)
           })
         })
-        readStream.pipe(inflateFilter)
-
-        if (this.zipFile.validateEntrySizes) {
-          endpointStream = new AssertByteCountStream(this.uncompressedSize)
-          inflateFilter.on('error', (err) => {
-            // forward zlib errors to the client-visible stream
-            setImmediate(() => {
-              if (!destroyed) endpointStream.emit('error', err)
-            })
-          })
-          inflateFilter.pipe(endpointStream)
-        } else {
-          // the zlib filter is the client-visible stream
-          endpointStream = inflateFilter
-        }
-
-        // this is part of yauzl's API, so implement this function on the client-visible stream
-        endpointStream.destroy = function () {
-          destroyed = true
-          if (inflateFilter !== endpointStream) inflateFilter.unpipe(endpointStream)
-          readStream.unpipe(inflateFilter)
-          // TODO: the inflateFilter may cause a memory leak. see Issue #27.
-          readStream.destroy()
-
-          return this
-        }
+        inflateFilter.pipe(endpointStream)
+      } else {
+        // the zlib filter is the client-visible stream
+        endpointStream = inflateFilter
       }
 
-      return endpointStream
-    } finally {
-      this.zipFile.reader.unref()
+      // this is part of yauzl's API, so implement this function on the client-visible stream
+      endpointStream.destroy = function() {
+        destroyed = true
+        if (inflateFilter !== endpointStream) inflateFilter.unpipe(endpointStream)
+        readStream.unpipe(inflateFilter)
+        // TODO: the inflateFilter may cause a memory leak. see Issue #27.
+        readStream.destroy()
+
+        return this
+      }
     }
+
+    return endpointStream
+  } finally {
+    zipFile.reader.unref()
+  }
+}
+
+export async function getBufferFromEntry(zipFile: ZipFile, entry: BaseEntry): Promise<Buffer> {
+  const stream = await getStreamFromEntry(zipFile, entry)
+  const buffers: Buffer[] = []
+
+  for await (const chunk of stream) {
+    buffers.push(chunk)
+  }
+
+  return Buffer.concat(buffers)
+}
+
+export class Entry extends BaseEntry {
+  constructor(
+    protected readonly zipFile: ZipFile,
+  ) {
+    super()
+  }
+
+  /**
+   * Get the file content as a stream.
+   *
+   * @throws {Error} If the zip file was closed.
+   */
+  public async getStream(): Promise<Transform> {
+    return getStreamFromEntry(this.zipFile, this)
   }
 
   /**
@@ -178,13 +202,10 @@ export class Entry {
    * @throws {Error} If the zip file was closed.
    */
   public async getBuffer(): Promise<Buffer> {
-    const stream = await this.getStream()
-    const buffers: Buffer[] = []
-
-    for await (const chunk of stream) {
-      buffers.push(chunk)
-    }
-
-    return Buffer.concat(buffers)
+    return getBufferFromEntry(this.zipFile, this)
   }
+}
+
+export class EntryWithContent extends BaseEntry {
+  public content!: Buffer;
 }

--- a/lib/yauzl-ts/inputProcessors.ts
+++ b/lib/yauzl-ts/inputProcessors.ts
@@ -8,9 +8,11 @@ import { decodeBuffer, defaultCallback, readAndAssertNoEof, readUInt64LE } from 
 export interface OpenOptions {
   autoClose?: boolean
   /**
+   * If true, the content of the files will be read and stored in memory.
+   *
    * @default false
    */
-  lazyEntries?: boolean
+  withContent?: boolean
   /**
    * @default true
    */
@@ -52,10 +54,10 @@ function parseOptions(
   if (typeof optionsOrCallback === 'function') {
     return [
       {
-        lazyEntries: false,
         decodeStrings: true,
         validateEntrySizes: true,
         strictFileNames: false,
+        withContent: false,
       },
       optionsOrCallback,
     ]
@@ -63,10 +65,10 @@ function parseOptions(
 
   const options = optionsOrCallback || {}
 
-  if (options.lazyEntries == null) options.lazyEntries = false
   if (options.decodeStrings == null) options.decodeStrings = true
   if (options.validateEntrySizes == null) options.validateEntrySizes = true
   if (options.strictFileNames == null) options.strictFileNames = false
+  if (options.withContent == null) options.withContent = false
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return [options, callbackOptional || defaultCallback]
@@ -230,10 +232,10 @@ export function fromRandomAccessReader<TReader extends IRandomAccessReader>(
             entryCount,
             comment,
             !!options.autoClose,
-            !!options.lazyEntries,
             decodeStrings,
             !!options.validateEntrySizes,
             !!options.strictFileNames,
+            !!options.withContent,
           ),
         )
       }
@@ -299,10 +301,10 @@ export function fromRandomAccessReader<TReader extends IRandomAccessReader>(
                   entryCount,
                   comment,
                   !!options.autoClose,
-                  !!options.lazyEntries,
                   decodeStrings,
                   !!options.validateEntrySizes,
                   !!options.strictFileNames,
+                  !!options.withContent,
                 ),
               )
             },


### PR DESCRIPTION
## Changes

Add support to extra via readable.

Being honest, I have very low experience with streams, so I have no idea how we can test backpressure or if my implementation is correct, so feel free to give any hints or suggestions on how we can improve this code.

I introduced an option on UnzipomaticOptions to extract the content automatically, I found this especially useful with `readable` since the readable stream will be closed before we were able to call `.getStream`.